### PR TITLE
refactor: remove SphericalJoint WASM bindings

### DIFF
--- a/physx/source/physxwebbindings/src/PxWebBindings.cpp
+++ b/physx/source/physxwebbindings/src/PxWebBindings.cpp
@@ -73,14 +73,6 @@ EMSCRIPTEN_BINDINGS(physx) {
                                                        actor1, PxTransform(localPosition1, localRotation1));
                       }),
                       allow_raw_pointers())  // ✅
-            .function("createSphericalJoint",
-                      optional_override([](PxPhysics &physics, PxRigidActor *actor0, const PxVec3 &localPosition0,
-                                           const PxQuat &localRotation0, PxRigidActor *actor1,
-                                           const PxVec3 &localPosition1, const PxQuat &localRotation1) {
-                          return PxSphericalJointCreate(physics, actor0, PxTransform(localPosition0, localRotation0),
-                                                        actor1, PxTransform(localPosition1, localRotation1));
-                      }),
-                      allow_raw_pointers())  // ✅
             .function("createDistanceJoint",
                       optional_override([](PxPhysics &physics, PxRigidActor *actor0, const PxVec3 &localPosition0,
                                            const PxQuat &localRotation0, PxRigidActor *actor1,

--- a/physx/source/physxwebbindings/src/binding/JointBinding.h
+++ b/physx/source/physxwebbindings/src/binding/JointBinding.h
@@ -30,20 +30,6 @@ EMSCRIPTEN_BINDINGS(physx_joint) {
     class_<PxFixedJoint, base<PxJoint>>("PxFixedJoint");
             // .function("setProjectionLinearTolerance", &PxFixedJoint::setProjectionLinearTolerance)     // ✅
             // .function("setProjectionAngularTolerance", &PxFixedJoint::setProjectionAngularTolerance);  // ✅
-    /* PhysXSphericalJoint ✅ */
-    // class_<PxSphericalJoint, base<PxJoint>>("PxSphericalJoint")
-    //         .function("setHardLimitCone", optional_override([](PxSphericalJoint &joint, PxReal yLimitAngle,
-    //                                                            PxReal zLimitAngle, PxReal contactDist) {
-    //                       joint.setLimitCone(PxJointLimitCone(yLimitAngle, zLimitAngle, contactDist));
-    //                   }))  // ✅
-    //         .function("setSoftLimitCone", optional_override([](PxSphericalJoint &joint, PxReal yLimitAngle,
-    //                                                            PxReal zLimitAngle, PxReal stiffness, PxReal damping) {
-    //                       joint.setLimitCone(PxJointLimitCone(yLimitAngle, zLimitAngle, PxSpring(stiffness, damping)));
-    //                   }));  // ✅
-            // .function("setSphericalJointFlag", optional_override([](PxSphericalJoint &joint, PxReal flag, bool value) {
-            //               joint.setSphericalJointFlag(PxSphericalJointFlag::Enum(flag), value);
-            //           }))                                                                                // ✅
-            // .function("setProjectionLinearTolerance", &PxSphericalJoint::setProjectionLinearTolerance);  // ✅
     /* PhysXHingeJoint ✅ */
     class_<PxRevoluteJoint, base<PxJoint>>("PxRevoluteJoint")
             .function("getAngle", &PxRevoluteJoint::getAngle)        // ✅


### PR DESCRIPTION
## Summary
- Remove `createSphericalJoint` factory function export from `PxPhysics` bindings
- Remove commented-out `PxSphericalJoint` class binding block from `JointBinding.h`

The SphericalJoint feature PR (galacean/engine#1341) has been closed, so the corresponding WASM interface bindings are no longer needed.

## Test plan
- [ ] Verify WASM build compiles successfully without SphericalJoint bindings
- [ ] Confirm no remaining SphericalJoint references in `physxwebbindings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)